### PR TITLE
use @compat fieldnames instead of typeof(x).names

### DIFF
--- a/src/JSON.jl
+++ b/src/JSON.jl
@@ -138,7 +138,7 @@ end
 
 function _print(io::IO, state::State, a)
     start_object(io, state, true)
-    range = typeof(a).names
+    range = @compat fieldnames(a)
     if length(range) > 0
         Base.print(io, prefix(state), "\"", range[1], "\"", colon(state))
         JSON._print(io, state, a.(range[1]))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -227,3 +227,11 @@ symtest = @compat Dict(:symbolarray => [:apple, :pear], :symbolsingleton => :hel
 @test (JSON.json(symtest) == "{\"symbolarray\":[\"apple\",\"pear\"],\"symbolsingleton\":\"hello\"}"
          || JSON.json(symtest) == "{\"symbolsingleton\":\"hello\",\"symbolarray\":[\"apple\",\"pear\"]}")
 
+# test for issue #109
+type t109
+   i::Int
+end
+let iob = IOBuffer()
+    JSON.print(iob, t109(1))
+    @test get(JSON.parse(takebuf_string(iob)), "i", 0) == 1
+end


### PR DESCRIPTION
Fixes this on Julia 0.4:

````
julia> type t
           i::Int
       end

julia> JSON.print(IOBuffer(), t(1))
ERROR: type DataType has no field names
 in _print at /home/tan/.julia/v0.4/JSON/src/JSON.jl:141
 in print at /home/tan/.julia/v0.4/JSON/src/JSON.jl:191 (repeats 2 times)
````