### PR TITLE
Fix #99 by correctly iterating through string

### DIFF
--- a/src/Parser.jl
+++ b/src/Parser.jl
@@ -53,12 +53,11 @@ end
 # Used for line counts
 function _count_before{T<:AbstractString}(haystack::T, needle::Char, _end::Int)
     count = 0
-    i = 1
-    while i < _end
-        haystack[i]==needle && (count += 1)
-        i += 1
+    for (i,c) in enumerate(haystack)
+        i >= _end && return count
+        count += c == needle
     end
-    count
+    return count
 end
 
 # Prints an error message with an indicator to the source

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -261,5 +261,8 @@ end
 @test_throws ErrorException JSON.parse("[5,2,-]")
 @test_throws ErrorException JSON.parse("[5,2,+β]")
 
+# Test for Issue #99
+@test_throws ErrorException JSON.parse("[\"🍕\"_\"🍕\"")
+
 # Check that printing to the default STDOUT doesn't fail
 JSON.print(["JSON.jl tests pass!"],1)


### PR DESCRIPTION
After:
```
ERROR: LoadError: Unexpected char: _
Line: 0
Around: ...["🍕"_"🍕"...
                  ^
```

Before:
```
ERROR: LoadError: UnicodeError: invalid character index
 in next at ./unicode/utf8.jl:65
```