### PR TITLE
Fix loading of precompiled JSON when DataStructures is not present

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,6 @@ sudo: false
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
     - julia -e 'Pkg.clone(pwd()); Pkg.build("JSON"); Pkg.test("JSON"; coverage=true)';
+    - julia -e 'using JSON' # loading after precompiled, but without DataStructures present
 after_success:
     - julia -e 'cd(Pkg.dir("JSON")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())';

--- a/src/Parser.jl
+++ b/src/Parser.jl
@@ -3,12 +3,13 @@ module Parser #JSON
 using Compat
 
 #Define ordered dictionary from DataStructures if present
-_HAVE_DATASTRUCTURES = try
-    using DataStructures
-    import DataStructures.OrderedDict
-    true
-catch
-    false
+function __init__()
+    global _HAVE_DATASTRUCTURES = try
+        @eval import DataStructures.OrderedDict
+        true
+    catch
+        false
+    end
 end
 
 const TYPES = Any # Union{Dict, Array, AbstractString, Number, Bool, Void} # Types it may encounter


### PR DESCRIPTION
closes #123

first commit adds a test to demonstrate failure case on travis, then second commit moves the conditional dependency on DataStructures into an `__init__` function.