### PR TITLE
change ordered keyword to dicttype keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,15 +52,18 @@ json(a::Any)
 Returns a compact JSON representation as an `AbstractString`.
 
 ```julia
-JSON.parse(s::AbstractString; ordered=false)
-JSON.parse(io::IO; ordered=false)
-JSON.parsefile(filename::AbstractString; ordered=false, use_mmap=true)
+JSON.parse(s::AbstractString; dicttype=Dict)
+JSON.parse(io::IO; dicttype=Dict)
+JSON.parsefile(filename::AbstractString; dicttype=Dict, use_mmap=true)
 ```
 
 Parses a JSON `AbstractString` or IO stream into a nested Array or Dict.
 
-If `ordered=true` is specified, JSON objects are parsed into
-`OrderedDicts`, which maintains the insertion order of the items in
-the object. (*)
-
-(*) Requires the `DataStructures.jl` package to be installed.
+The `dicttype` indicates the dictionary type (`<: Associative`) that
+JSON objects are parsed to.  It defaults to `Dict` (the built-in Julia
+dictionary), but a different type can be passed to, for example,
+provide a desired ordering.  For example, if you `import DataStructures`
+(assuming the [DataStructures
+package](https://github.com/JuliaLang/DataStructures.jl) is
+installed), you can pass `dicttype=DataStructures.OrderedDict` to
+maintain the insertion order of the items in the object.

--- a/src/JSON.jl
+++ b/src/JSON.jl
@@ -253,7 +253,7 @@ function consumeString(io::IO, obj::IOBuffer)
     throw(EOFError())
 end
 
-function parse(io::IO; ordered::Bool=false)
+function parse{T<:Associative}(io::IO; dicttype::Type{T}=Dict)
     open_bracket = close_bracket = nothing
     try
         open_bracket, close_bracket = determine_bracket_type(io)
@@ -278,14 +278,14 @@ function parse(io::IO; ordered::Bool=false)
             consumeString(io, obj)
         end
     end
-    JSON.parse(takebuf_string(obj), ordered=ordered)
+    JSON.parse(takebuf_string(obj); dicttype=dicttype)
 end
 
-function parsefile(filename::AbstractString; ordered::Bool=false, use_mmap=true)
+function parsefile{T<:Associative}(filename::AbstractString; dicttype::Type{T}=Dict, use_mmap=true)
     sz = filesize(filename)
     open(filename) do io
         s = use_mmap ? UTF8String(Mmap.mmap(io, Vector{UInt8}, sz)) : readall(io)
-        JSON.parse(s, ordered=ordered)
+        JSON.parse(s; dicttype=dicttype)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ import DataStructures
 
 include(joinpath(dirname(@__FILE__),"json_samples.jl"))
 
-@test JSON.parse("{\"x\": 3}"; ordered = true) == DataStructures.OrderedDict{AbstractString,Any}([("x",3)])
+@test JSON.parse("{\"x\": 3}", dicttype=DataStructures.OrderedDict) == DataStructures.OrderedDict{AbstractString,Any}([("x",3)])
 
 # Test definitions -------
 validate_c(c) = begin


### PR DESCRIPTION
As discussed in #128, this provides more flexibility, and avoids the pseudo-dependency on DataStructures that has been causing precompilation problems.