### PR TITLE
Correct Date/DateTime

### DIFF
--- a/src/JSON.jl
+++ b/src/JSON.jl
@@ -88,6 +88,10 @@ function _print(io::IO, state::State, s::AbstractString)
     Base.print(io, '"')
 end
 
+function _print(io::IO, state::State, s::Base.Dates.TimeType)
+    _print(io, state, string(s))
+end
+
 function _print(io::IO, state::State, s::Symbol)
     _print(io, state, string(s))
 end

--- a/src/JSON.jl
+++ b/src/JSON.jl
@@ -88,8 +88,10 @@ function _print(io::IO, state::State, s::AbstractString)
     Base.print(io, '"')
 end
 
-function _print(io::IO, state::State, s::Base.Dates.TimeType)
-    _print(io, state, string(s))
+if isdefined(Base, :Dates)
+    function _print(io::IO, state::State, s::Base.Dates.TimeType)
+        _print(io, state, string(s))
+    end
 end
 
 function _print(io::IO, state::State, s::Symbol)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -253,6 +253,14 @@ end
 @test sprint(JSON.print, Float64) == string("\"Float64\"")
 @test_throws ArgumentError sprint(JSON.print, JSON)
 
+# test for issue #90 - Date/DateTime
+if VERSION >= v"0.4.6-pre+18"
+@test json(Date("2016-04-13")) == "\"2016-04-13\""
+@test json([Date("2016-04-13"), Date("2016-04-12")]) == "[\"2016-04-13\",\"2016-04-12\"]"
+@test json(DateTime("2016-04-13T00:00:00")) == "\"2016-04-13T00:00:00\""
+@test json([DateTime("2016-04-13T00:00:00"), DateTime("2016-04-12T00:00:00")]) == "[\"2016-04-13T00:00:00\",\"2016-04-12T00:00:00\"]"
+end
+
 # Test parser failures
 # Unexpected character in array
 @test_throws ErrorException JSON.parse("[1,2,3/4,5,6,7]")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -254,7 +254,7 @@ end
 @test_throws ArgumentError sprint(JSON.print, JSON)
 
 # test for issue #90 - Date/DateTime
-if VERSION >= v"0.4.6-pre+18"
+if isdefined(Base, :Dates)
 @test json(Date("2016-04-13")) == "\"2016-04-13\""
 @test json([Date("2016-04-13"), Date("2016-04-12")]) == "[\"2016-04-13\",\"2016-04-12\"]"
 @test json(DateTime("2016-04-13T00:00:00")) == "\"2016-04-13T00:00:00\""


### PR DESCRIPTION
Fixes #90 and https://github.com/johnmyleswhite/Vega.jl/issues/107

Vega.jl examples to show this works in the wild (i.e. parses `Date/DateTime` to a readable format that a JavaScript library will accept and in proper ordinal order)

![download 3](https://cloud.githubusercontent.com/assets/2762787/14505846/f77b6740-0188-11e6-83d9-1ecf9dffac40.png)
![download](https://cloud.githubusercontent.com/assets/2762787/14505833/e7dd86f6-0188-11e6-8e11-9dbdbfe810bd.png)




