### PR TITLE
Fix @os_only deprecation warnings

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.3
-Compat 0.7.16
+Compat 0.7.20

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -211,9 +211,12 @@ obj = JSON.parse("{\"\U0001d712\":\"\\ud835\\udf12\"}")
 tmppath, io = mktemp()
 write(io, facebook)
 close(io)
-@unix_only @test haskey(JSON.parsefile(tmppath), "data")
-# don't use mmap on Windows, to avoid ERROR: unlink: operation not permitted (EPERM)
-@windows_only @test haskey(JSON.parsefile(tmppath; use_mmap=false), "data")
+if is_windows()
+    # don't use mmap on Windows, to avoid ERROR: unlink: operation not permitted (EPERM)
+    @test haskey(JSON.parsefile(tmppath; use_mmap=false), "data")
+else
+    @test haskey(JSON.parsefile(tmppath), "data")
+end
 rm(tmppath)
 
 # check indented json has same final value as non indented


### PR DESCRIPTION
Having red text be printed every time `Pkg.test("JSON")` is run is getting tiresome. Compat has the new `is_windows()` function, and these macros are not coming back (https://github.com/JuliaLang/julia/pull/16658).

Also bumped the Compat version to what is appropriate. With this and #140, there is no more red output for tests on release or master.

Closes #146