### PR TITLE
Add JSON.lower for a better serialization API

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,5 +73,5 @@ JSON.lower(p::Point2D) = [x.x, x.y]
 ```
 
 Define a custom serialization rule for a particular data type. Must return a
-value that can be directly serialized; see help for more details. Do **not**
-extend `JSON._print`; that is a clunky API and is now deprecated.
+value that can be directly serialized; see help for more details. Note that
+`JSON._print` is deprecated and will eventually been discontinued.

--- a/README.md
+++ b/README.md
@@ -67,3 +67,11 @@ provide a desired ordering.  For example, if you `import DataStructures`
 package](https://github.com/JuliaLang/DataStructures.jl) is
 installed), you can pass `dicttype=DataStructures.OrderedDict` to
 maintain the insertion order of the items in the object.
+
+```julia
+JSON.lower(p::Point2D) = [x.x, x.y]
+```
+
+Define a custom serialization rule for a particular data type. Must return a
+value that can be directly serialized; see help for more details. Do **not**
+extend `JSON._print`; that is a clunky API and is now deprecated.

--- a/src/JSON.jl
+++ b/src/JSON.jl
@@ -200,15 +200,14 @@ end
 function _writejson(io::IO, state::State, a)
     # FIXME: This fallback is harming performance substantially.
     # Remove this fallback when _print removed.
-    #= if applicable(_print, io, state, a)
+    if applicable(_print, io, state, a)
         Base.depwarn(
             "Overloads to `_print` are deprecated; extend `lower` instead.",
             :_print)
         _print(io, state, a)
     else
         _writejson(io, state, lower(a))
-    end =#
-    _writejson(io, state, lower(a))
+    end
 end
 
 # Note: Arrays are printed in COLUMN MAJOR format.

--- a/test/lowering.jl
+++ b/test/lowering.jl
@@ -1,0 +1,17 @@
+if isdefined(Base, :Dates)
+    @test JSON.json(Date(2016, 8, 3)) == "\"2016-08-03\""
+end
+
+@test JSON.json(:x) == "\"x\""
+@test_throws ArgumentError JSON.json(Base)
+
+immutable Type151{T}
+    x::T
+end
+
+@test JSON.json(Type151) == "\"Type151{T}\""
+
+JSON.lower{T}(v::Type151{T}) = @compat Dict(:type => T, :value => v.x)
+@test JSON.parse(JSON.json(Type151(1.0))) == @compat Dict(
+    "type" => "Float64",
+    "value" => 1.0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -291,3 +291,6 @@ end
 
 # Check that printing to the default STDOUT doesn't fail
 JSON.print(["JSON.jl tests pass!"],1)
+
+# Lowering tests
+include("lowering.jl")


### PR DESCRIPTION
Implements the idea in #150. The following is a quick recap (redundant with #150) of why this is needed:

Lots of packages currently overload `JSON._print` to define custom JSON serialization. This is really bad, because:

- Packages need to reimplement a lot of serialization code, like how to serialize dicts and arrays.
- Overloads of JSON._print can write anything — including stuff that isn't JSON. This isn't good.
- Packages tend to depend on implementation details, like what the name of JSON.separator is.
- Packages work independently of the existing parser system, so they do not benefit from updates to serialization code here.

This PR implements:

- Introduce JSON.lower, designed to be overloaded, that converts an object to another "primitive" object that JSON can serialize (Dict, Array, etc.).
- In the generic JSON._print fallback, call JSON.lower instead of the current dumping behaviour
- Add a generic JSON.lower fallback that does the current dumping behaviour
- Rename JSON._print to JSON._writejson, and add an additional deprecated fallback to a new JSON._print with no methods defined

To make review easier, changes are separated into separate commits.