### PR TITLE
Remove usage of `line_buffered`

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,7 +58,6 @@ end
     s = listen(7777)
     s = accept(s)
 
-    s.line_buffered = false
     Base.start_reading(s)
 
     @test JSON.parse(s) != nothing  # a


### PR DESCRIPTION
As pointed out by @vtjnash, this wasn't doing anything. It also was only used in this particular test.